### PR TITLE
Support inventory-group upstreams for Caddy reverse proxies

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -15,6 +15,7 @@
 
 {% if caddy_endpoints is defined %}
 {% for endpoint in caddy_endpoints %}
+{% set endpoint_upstream = endpoint.upstream if endpoint.upstream is defined else (groups[endpoint.upstream_group] | map('regex_replace', '$', ':4000') | join(' ')) %}
 
 # {{ endpoint.friendly_name }}
 {% if endpoint.fqdn.startswith("*") %}
@@ -23,17 +24,18 @@
 
 {% if endpoint.wildcard_endpoints is defined %}
 {% for wildcard_endpoint in endpoint.wildcard_endpoints %}
+    {% set wildcard_upstream = wildcard_endpoint.upstream if wildcard_endpoint.upstream is defined else (groups[wildcard_endpoint.upstream_group] | map('regex_replace', '$', ':4000') | join(' ')) %}
     @{{ ( wildcard_endpoint.fqdn | split(".") )[0] }} host {{ wildcard_endpoint.fqdn }}
     handle @{{ ( wildcard_endpoint.fqdn | split(".") )[0] }} {
 {% if wildcard_endpoint.tls_insecure | default(false) %}
-        reverse_proxy {{ wildcard_endpoint.upstream }} {
+        reverse_proxy {{ wildcard_upstream }} {
             transport http {
                 tls_insecure_skip_verify
             }
         }
     }
 {% else %}
-        reverse_proxy {{ wildcard_endpoint.upstream }}
+        reverse_proxy {{ wildcard_upstream }}
     }
 {% endif %}
 {% endfor %}
@@ -46,7 +48,7 @@
 {% else %}
 {% if endpoint.tls_insecure | default(false) %}
 {{ endpoint.fqdn }} {
-    reverse_proxy {{ endpoint.upstream }} {
+    reverse_proxy {{ endpoint_upstream }} {
         transport http {
             tls_insecure_skip_verify
         }
@@ -55,7 +57,7 @@
 }
 {% else %}
 {{ endpoint.fqdn }} {
-    reverse_proxy {{ endpoint.upstream }}
+    reverse_proxy {{ endpoint_upstream }}
     import {{ endpoint.tls_provider }}
 }
 {% endif %}


### PR DESCRIPTION
## Summary

This change lets the Caddy role build reverse proxy upstreams from an
Ansible inventory group instead of requiring a single static upstream
value like `appnode:4000`.

## Why

Our deployment now runs multiple app nodes. A single hardcoded upstream
no longer reflects the topology, and we want Caddy to automatically
target all hosts in the `app` inventory group.

## Changes

- add support for `upstream_group` in `Caddyfile.j2`
- expand inventory hosts into a space-separated `host:4000` upstream list
- keep existing `upstream` support unchanged for backwards compatibility
- apply the same group-based behavior to wildcard endpoints as well

## Example

Before:
```yaml
caddy_endpoints:
  - friendly_name: spinspot-app
    fqdn: app.spinspot.live
    upstream: appnode:4000
```
After:
```yaml
caddy_endpoints:
  - friendly_name: spinspot-app
    fqdn: app.spinspot.live
    upstream_group: app
```
This renders to something like:
```caddy
reverse_proxy spinspot-appnode-1:4000 spinspot-appnode-2:4000 spinspot-appnode-3:4000
```
Validation
- verified the Ansible inventory still parses correctly
- verified the template preserves explicit upstream behavior
- verified group-based upstream rendering works for multi-node app groups